### PR TITLE
Remove duplicate 'homepage' key in `theme.toml`

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -3,7 +3,6 @@ description = "A timeless blog theme"
 license = "MIT"
 homepage = "https://github.com/sirodoht/zola-henry"
 min_version = "0.4.0"
-homepage = "https://github.com/sirodoht/zola-henry"
 demo = "https://sirodoht.github.io/zola-henry/"
 
 [author]


### PR DESCRIPTION
While generating docs for [Zola themes](https://github.com/getzola/themes), I encountered a `TomlDecodeError` caused by a duplicate `homepage` key in the `theme.toml` of this theme.

To reproduce the error, follow these steps:

1. Clone the Zola themes repository:

```bash
git clone https://github.com/getzola/themes
cd themes
```

2. Initialize and update the submodules:

```bash
git submodule update --init --recursive
git submodule update --remote --merge
```

3. Create a `docs` directory and run the documentation generator script:

```bash
mkdir docs
python generate_docs.py docs
```

Following the above steps before this fix led to a TOML decoding error because of the duplicate key in `theme.toml`.

## Changes made

Removed the duplicate homepage key from `theme.toml` file.
